### PR TITLE
Updating supported doc versions

### DIFF
--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -5,8 +5,6 @@ owner: Partners
 
 VMware Harbor Registry is an enterprise-class registry server that stores and distributes container images. Harbor allows you to store and manage images for use with <%= vars.product_pks_full %> (<%= vars.product_pks_short %>).
 
-<p class="note"><strong>Note:</strong> This documentation supports the Harbor v1.9.x, v1.10.x, and v2.0.x releases.</p>
-
 ## <a id="overview"></a> Overview
 
 Harbor extends the open source Docker Distribution by adding the functionalities usually required by an enterprise, such as security, identity, and management. As an enterprise private registry, Harbor offers enhanced performance and security. Deploying a registry alongside the <%= vars.product_pks_short %> environment improves image management efficiency.

--- a/docs-content/installing.html.md.erb
+++ b/docs-content/installing.html.md.erb
@@ -10,8 +10,6 @@ For more information about <%= vars.product_pks_short %>, see the [<%= vars.prod
 
 For more information about TAS for VMs, see [TAS for VMs Concepts](https://docs.pivotal.io/pivotalcf/concepts/index.html) in the Pivotal documentation.
 
-<p class="note"><strong>Note:</strong> This documentation supports the Harbor v1.9.x and 1.10.x releases.</p>
-
 ## <a id='prereqs'></a> Prerequisites
 
 You must have installed <%= vars.product_pks_short %>. For more information, see [Installing <%= vars.product_pks_short %>](https://docs.pivotal.io/tkgi/installing.html) in the <%= vars.product_pks_short %> documentation.

--- a/docs-content/release-notes.html.md.erb
+++ b/docs-content/release-notes.html.md.erb
@@ -41,6 +41,10 @@ The table provides version, compatibility, and upgrade information for this rele
     <tr>
        <td>Supported Upgrade Paths</td>
        <td>From Harbor v2.1.x, v2.0.x and v1.10.x</td>
+    <tr>
+       <td>Supported Documentation versions</td>
+       <td>This documentaton supports Harbor v2.1.x, v2.0.x and v1.10.x</td>
+    </tr>    
 </table>
 
 ### <a id="v2.1.3_fixed"></a> Fixed Issues


### PR DESCRIPTION
Clarified the supported versions:
The index page says: "Harbor v1.9.x, v1.10.x, and v2.0.x releases."
The installing page says: "Harbor v1.9.x and 1.10.x releases."
The release notes page suggests: 2.1.x might also be supported. (edited) 
Removed the two orphaned and inconsistent notes, put a definitive statement in the RNs.