### PR TITLE
Update reqs ops mgr only

### DIFF
--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -1,13 +1,13 @@
 ---
-title: VMware Harbor Registry
+title: VMware Harbor Registry Tile
 owner: Partners
 ---
 
-VMware Harbor Registry is an enterprise-class registry server that stores and distributes container images. Harbor allows you to store and manage images for use with <%= vars.product_pks_full %> (<%= vars.product_pks_short %>).
+VMware Harbor Registry is an enterprise-class registry server that stores and distributes container images. You can install the VMware Harbor Container Registry Tile in Ops Manager to store and manage images for use with Kubernetes.
 
 ## <a id="overview"></a> Overview
 
-Harbor extends the open source Docker Distribution by adding the functionalities usually required by an enterprise, such as security, identity, and management. As an enterprise private registry, Harbor offers enhanced performance and security. Deploying a registry alongside the <%= vars.product_pks_short %> environment improves image management efficiency.
+Harbor extends the open source Docker Distribution by adding the functionalities usually required by an enterprise, such as security, identity, and management. As an enterprise private registry, Harbor offers enhanced performance and security. Deploying a registry alongside the Kubernetes environment improves image management efficiency.
 
 
 ## <a id="features"></a> Key Features

--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -3,16 +3,17 @@ title: VMware Harbor Registry Tile
 owner: Partners
 ---
 
-VMware Harbor Registry is an enterprise-class registry server that stores and distributes container images. You can install the VMware Harbor Container Registry Tile in Ops Manager to store and manage images for use with Kubernetes.
+VMware Harbor Registry is an enterprise-class registry server that stores and distributes container images. You can install the VMware Harbor Registry Tile in Tanzu Operations Manager to store and manage images for use with your VMware Tanzu Kubernetes deployments.
 
 ## <a id="overview"></a> Overview
 
-Harbor extends the open source Docker Distribution by adding the functionalities usually required by an enterprise, such as security, identity, and management. As an enterprise private registry, Harbor offers enhanced performance and security. Deploying a registry alongside the Kubernetes environment improves image management efficiency.
+VMware Harbor Registry extends the [open source](https://goharbor.io/) Harbor distribution by adding the functionalities usually required by an enterprise, such as security, identity, and management. As an enterprise private registry, Harbor offers enhanced performance and security. Deploying a registry alongside the Kubernetes environment improves image management efficiency.
 
+The VMware Harbor Registry Tile provides a convenient package for installing VMware Harbor Registry using VMware Tanzu Operations Manager.
 
 ## <a id="features"></a> Key Features
 
-Harbor includes the following key features:
+VMware Harbor Registry includes the following key features:
 
 * **Replicate projects**: Harbor supports images replication to replicate repositories from one Harbor instance to another.
 * **Manage role by LDAP group**: Harbor administrators can import an LDAP/AD group to Harbor and assign project roles to it.
@@ -31,7 +32,7 @@ Harbor includes the following key features:
 
 ## <a id="releases"></a> Releases
 
-Refer to the [release notes](./release-notes.html) information on Harbor Registry releases, including versions, compatibility, features, requirements, known issues, and limitations.
+Refer to the [release notes](./release-notes.html) information on VMware Harbor Registry Tile releases, including versions, compatibility, features, requirements, known issues, and limitations.
 
 ## <a id="feedback"></a> Feedback
 

--- a/docs-content/installing.html.md.erb
+++ b/docs-content/installing.html.md.erb
@@ -1,22 +1,17 @@
 ---
-title: Installing and Configuring VMware Harbor Registry
+title: Installing and Configuring the VMware Harbor Registry Tile
 owner: Partners
 ---
 
-This topic describes how to install and configure VMware Harbor Registry using Ops Manager
-for use with <%= vars.product_pks_full %> (<%= vars.product_pks_short %>) and VMware Tanzu Application Service for VMs (TAS for VMs).
+This topic describes how to install and configure the VMware Harbor Registry Tile for use with your VMware Tanzu Kubernetes deployments.
 
-For more information about <%= vars.product_pks_short %>, see the [<%= vars.product_pks_full %>](https://docs.pivotal.io/tkgi/index.html) documentation.
+These instructions are valid for new installations, reconfigurations of existing installations, and upgrades. If you are upgrading the Harbor Registry Tile, follow the procedure in [Upgrading the VMware Harbor Registry Tile](upgrading.html) before performing these steps.
 
-For more information about TAS for VMs, see [TAS for VMs Concepts](https://docs.pivotal.io/pivotalcf/concepts/index.html) in the Pivotal documentation.
+## <a id='prereqs'></a> Prerequisite: VMware Tanzu Operations Manager
 
-## <a id='prereqs'></a> Prerequisites
+To install, configure, or upgrade the VMware Harbor Registry Tile, you must have the VMware Tanzu Operations Manager installed. Refer to the Operations Manager [documentation](https://docs.vmware.com/en/VMware-Tanzu-Operations-Manager/index.html) for instructions. Check the VMware Harbor Registry Tile [release notes](https://docs.vmware.com/en/VMware-Harbor-Registry/services/vmware-harbor-registry/GUID-release-notes.html) for supported Operations Manager versions.
 
-To install the Harbor Registry tile, you must have Ops Manager installed. If you are using Harbor with TKGI, see [Deploying Ops Manager with NSX-T for <%= vars.product_pks_short %>](https://docs.pivotal.io/tkgi/1-12/vsphere-nsxt-om-deploy.html). If you are using Harbor with [TAS](https://docs.pivotal.io/application-service/2-12/concepts/overview.html), see [Ops Manager Installation](https://docs.pivotal.io/ops-manager/2-10/install/index.html).
-
-These instructions are valid for new installations, reconfigurations of existing installations, or upgrades. If you are upgrading Harbor, follow the procedure in [Upgrading VMware Harbor Registry](upgrading.html) before performing these steps.
-
-## <a id='install'></a> Import Harbor Tile to Ops Manager
+## <a id='install'></a> Import the VMware Harbor Registry Tile to Ops Manager
 
 To initiate the deployment of Harbor, import the tile.
 

--- a/docs-content/release-notes.html.md.erb
+++ b/docs-content/release-notes.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: VMware Harbor Container Registry Release Notes for VMware Tanzu Kubernetes Grid Integrated Edition
+title: VMware Harbor Container Registry Tile Release Notes
 owner: Partners
 ---
 
@@ -7,7 +7,7 @@ owner: Partners
 
 ## <a id='v2.9.1'></a> v2.9.1
 
-VMware Harbor Container Registry for TKGI v2.9.1 a is a maintenance release with [enhancements](#v2.9.1_enhancements) and [fixes](#v2.9.1_fixed).
+VMware Harbor Container Registry Tile v2.9.1 a is a maintenance release with [enhancements](#v2.9.1_enhancements) and [fixes](#v2.9.1_fixed).
 
 ### <a id="v2.9.1_snapshot"></a> Release Snapshot
 

--- a/docs-content/release-notes.html.md.erb
+++ b/docs-content/release-notes.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: VMware Harbor Container Registry Tile Release Notes
+title: VMware Harbor Registry Tile Release Notes
 owner: Partners
 ---
 

--- a/docs-content/upgrading.html.md.erb
+++ b/docs-content/upgrading.html.md.erb
@@ -1,17 +1,15 @@
 ---
-title: Upgrading VMware Harbor Registry
+title: Upgrading the VMware Harbor Registry Tile
 owner: Partners
 ---
 
-This topic describes how to upgrade VMware Harbor Registry tile using Ops Manager.
-
-<p class="note"><strong>Note:</strong> This documentation supports the Harbor v1.9.x and 1.10.x releases.</p>
+This topic describes how to upgrade VMware Harbor Registry Tile using VMware Tanzu Operations Manager.
 
 ## <a id='prereqs'></a> Prerequisites
 
-These instructions assume that Harbor Registry is installed and configured. See [Installing and Configuring Harbor](./installing.html) for more information.
+These instructions assume that the VMware Harbor Registry Tile is installed and configured. See [Installing and Configuring the VMware Harbor Registry Tile](./installing.html) for more information.
 
-## <a id='upgrade'></a> Import the Harbor Tile
+## <a id='upgrade'></a> Import the Harbor Registry Tile to Operations Manager
 
 1. Review the [Harbor Release Notes](./release-notes.html) and verify the supported upgrade path.
 1. Download the Harbor tile from [Pivotal Network](https://network.pivotal.io/).
@@ -27,7 +25,7 @@ These instructions assume that Harbor Registry is installed and configured. See 
 
 ## <a id='stemcell'></a> Import the Required Stemcell (if necessary)
 
-The Harbor tile upgrade may require a new stemcell. If so, complete the following steps to import it.
+The Harbor Registry Tile upgrade may require a new stemcell. If so, complete the following steps to import it.
 
 1. In Ops Manager, return to the **Installation Dashboard**.
 1. In the Harbor tile, click the **Missing stemcell** link.
@@ -43,7 +41,7 @@ The Harbor tile upgrade may require a new stemcell. If so, complete the followin
 	<img src="images/import-stemcell.png" alt="Import required stemcell for Harbor" width="625">
 1. When prompted, apply the imported stemcell to the Harbor product.
 
-## <a id='deploy'></a> Deploy Harbor with Upgrades
+## <a id='deploy'></a> Deploy the Harbor Registry Tile with Upgrades
 
 To complete the Harbor upgrade, deploy the newly added Harbor tile. When an updated version of the Harbor tile is deployed, Ops Manager will create a new VM based on the required stemcell, install the Harbor software on that VM, mount the disk on it and migrate the data to the new VM.
 

--- a/docs-content/using.html.md.erb
+++ b/docs-content/using.html.md.erb
@@ -1,11 +1,9 @@
 ---
-title: Using VMware Harbor Registry
+title: Using the VMware Harbor Registry Tile
 owner: Partners
 ---
 
-This topic describes how to use the VMware Harbor Registry integration with <%= vars.product_pks_full %> (<%= vars.product_pks_short %>).
-
-<p class="note"><strong>Note:</strong> This documentation supports the Harbor v1.9.x and 1.10.x releases.</p>
+This topic describes how to use the VMware Harbor Registry Tile installation.
 
 ## <a id='prereqs'></a> Prerequisites
 


### PR DESCRIPTION
Updating docs to focus on installation in Tanzu Operations Manager for use with all the various Tanzu Kubernetes deployments, not just TKGI. 